### PR TITLE
Add advanced search API support to marketplace plugin search

### DIFF
--- a/dify-plugin-repackaging-web/backend/app/services/marketplace.py
+++ b/dify-plugin-repackaging-web/backend/app/services/marketplace.py
@@ -134,6 +134,26 @@ class MarketplaceService:
             # Try multiple API endpoints in order
             api_attempts = [
                 {
+                    "url": "https://marketplace.dify.ai/api/v1/plugins/search/advanced",
+                    "method": "POST",
+                    "json": {
+                        "page": page,
+                        "page_size": per_page,
+                        "query": query or "",
+                        "sort_by": "install_count",
+                        "sort_order": "DESC",
+                        "category": category or "",
+                        "tags": [],
+                        "type": "plugin"
+                    },
+                    "transformer": lambda r: {
+                        "plugins": r.get("data", r.get("plugins", [])),
+                        "total": r.get("total", len(r.get("data", r.get("plugins", [])))),
+                        "page": page,
+                        "per_page": per_page
+                    }
+                },
+                {
                     "url": "https://marketplace.dify.ai/api/v1/plugins",
                     "method": "GET",
                     "params": params,


### PR DESCRIPTION
## Summary
- Adds support for an advanced search API endpoint in the marketplace plugin search service
- Implements POST request with enhanced filtering and sorting options
- Provides fallback to existing GET endpoint if advanced search is unavailable

## Changes

### Backend Service Updates
- **MarketplaceService**: Added a new API attempt for advanced search using POST to `https://marketplace.dify.ai/api/v1/plugins/search/advanced`
  - Supports pagination, query, category filtering, and sorting by install count in descending order
  - Transforms response to unify plugin list, total count, and pagination info
- Retains existing GET request to `https://marketplace.dify.ai/api/v1/plugins` as fallback

## Test plan
- [ ] Verify that plugin search returns results using the advanced search endpoint
- [ ] Confirm fallback to the original GET endpoint works correctly
- [ ] Test pagination, sorting, and filtering parameters for expected behavior
- [ ] Ensure response transformation correctly maps API data to internal format

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4c986c97-b035-4ae1-a94e-e3598c8dcda8