### PR TITLE
Security: remove auth headers and unify 401 messaging

### DIFF
--- a/dify-plugin-repackaging-web/backend/app/core/security.py
+++ b/dify-plugin-repackaging-web/backend/app/core/security.py
@@ -155,8 +155,7 @@ async def verify_authentication(request: Request) -> bool:
             auth_rate_limiter.record_attempt(client_id)
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid authentication token",
-                headers={"WWW-Authenticate": "Bearer"}
+                detail="Invalid authentication token"
             )
 
     # Method 2: Check HTTP Basic Auth
@@ -174,8 +173,7 @@ async def verify_authentication(request: Request) -> bool:
                 auth_rate_limiter.record_attempt(client_id)
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid credentials",
-                    headers={"WWW-Authenticate": 'Basic realm="Dify Plugin Repackaging"'}
+                    detail="Invalid credentials"
                 )
 
     # No authentication provided
@@ -183,8 +181,7 @@ async def verify_authentication(request: Request) -> bool:
     auth_rate_limiter.record_attempt(client_id)
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required. Provide X-Auth-Token header or HTTP Basic Auth.",
-        headers={"WWW-Authenticate": 'Basic realm="Dify Plugin Repackaging"'}
+        detail="Authentication required. Provide X-Auth-Token header or HTTP Basic Auth."
     )
 
 

--- a/dify-plugin-repackaging-web/frontend/src/contexts/AuthContext.tsx
+++ b/dify-plugin-repackaging-web/frontend/src/contexts/AuthContext.tsx
@@ -50,14 +50,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Listen for unauthorized events from axios interceptor
   useEffect(() => {
-    const handleUnauthorized = () => {
+    const handleUnauthorized = (event?: CustomEvent) => {
       setToken(null);
-      setAuthError('Invalid password. Please try again.');
+      // Ensure authError is always a string
+      const message = typeof event?.detail === 'string'
+        ? event.detail
+        : 'Invalid password. Please try again.';
+      setAuthError(message);
     };
 
-    window.addEventListener('auth:unauthorized', handleUnauthorized);
+    window.addEventListener('auth:unauthorized', handleUnauthorized as EventListener);
     return () => {
-      window.removeEventListener('auth:unauthorized', handleUnauthorized);
+      window.removeEventListener('auth:unauthorized', handleUnauthorized as EventListener);
     };
   }, []);
 

--- a/dify-plugin-repackaging-web/frontend/src/services/utils/axiosDefaults.ts
+++ b/dify-plugin-repackaging-web/frontend/src/services/utils/axiosDefaults.ts
@@ -49,7 +49,7 @@ export function configureAxiosDefaults(): void {
       // Handle 401 Unauthorized - clear token and trigger re-login
       if (error.response && error.response.status === 401) {
         localStorage.removeItem(AUTH_TOKEN_KEY);
-        // Dispatch custom event to notify AuthProvider
+        // Dispatch custom event to notify AuthProvider (no detail to ensure string-only authError)
         window.dispatchEvent(new CustomEvent('auth:unauthorized'));
       }
 


### PR DESCRIPTION
## Summary
Security improvements to authentication flow:
- Remove WWW-Authenticate headers from 401 responses
- Normalize frontend unauthorized handling to use string-based messages
- Dispatch auth:unauthorized without details to ensure string-only messaging

## Changes

### Backend
- dify-plugin-repackaging-web/backend/app/core/security.py
  - Removed WWW-Authenticate headers from 401 responses for invalid token, invalid credentials, and missing authentication scenarios. Responses now contain only the detail message.

### Frontend
- dify-plugin-repackaging-web/frontend/src/contexts/AuthContext.tsx
  - Updated handleUnauthorized to accept an optional event and derive a string error message from event.detail when available; otherwise fall back to a safe default.
  - Casts event listener types to ensure compatibility with TypeScript.
- dify-plugin-repackaging-web/frontend/src/services/utils/axiosDefaults.ts
  - When a 401 is detected, dispatch auth:unauthorized without detail to guarantee string-only messaging for the UI error state.

## Test plan
- [x] Backend: Verify 401 responses no longer include WWW-Authenticate headers for token/credential failures and missing auth
- [x] Frontend: Simulate unauthorized events and confirm AuthContext displays a consistent string error
- [x] Integration: Trigger API 401s and ensure auth:unauthorized is emitted with a string message (no detail), token is cleared, and UI prompts re-login


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/aec1c2b2-3456-4f5e-b0a9-1400800ecbee