### PR TITLE
Fix authentication flow and marketplace access with token interceptors

### DIFF
--- a/dify-plugin-repackaging-web/frontend/src/main.jsx
+++ b/dify-plugin-repackaging-web/frontend/src/main.jsx
@@ -3,16 +3,12 @@ import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
-// Defer utility imports to avoid initialization issues
-setTimeout(() => {
-  import('./services/utils/axiosDefaults').then(({ configureAxiosDefaults }) => {
-    configureAxiosDefaults();
-  });
-  
-  import('./utils/globalErrorHandler').then(({ installGlobalErrorHandlers }) => {
-    installGlobalErrorHandlers();
-  });
-}, 0);
+// Import and configure axios defaults synchronously to ensure auth interceptors are ready
+import { configureAxiosDefaults } from './services/utils/axiosDefaults';
+import { installGlobalErrorHandlers } from './utils/globalErrorHandler';
+
+configureAxiosDefaults();
+installGlobalErrorHandlers();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/dify-plugin-repackaging-web/frontend/src/services/files.ts
+++ b/dify-plugin-repackaging-web/frontend/src/services/files.ts
@@ -1,7 +1,6 @@
 import api from './api';
 import type { FileInfo, FileListResponse } from '../types/file';
-import axios from 'axios';
-import { withErrorHandling, logError } from './utils/errorHandler';
+import { withErrorHandling } from './utils/errorHandler';
 
 const API_BASE_URL = '/api/v1';
 

--- a/dify-plugin-repackaging-web/frontend/src/services/marketplace.ts
+++ b/dify-plugin-repackaging-web/frontend/src/services/marketplace.ts
@@ -1,6 +1,5 @@
-import axios, { AxiosError } from 'axios';
 import { createAxiosWithRetry } from './utils/retry';
-import { withErrorHandling, toApiError, logError, getUserFriendlyErrorMessage } from './utils/errorHandler';
+import { withErrorHandling, toApiError } from './utils/errorHandler';
 
 const API_BASE_URL = '/api/v1';
 

--- a/dify-plugin-repackaging-web/frontend/src/services/utils/retry.ts
+++ b/dify-plugin-repackaging-web/frontend/src/services/utils/retry.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
+const AUTH_TOKEN_KEY = 'auth_token';
+
 interface RetryConfig {
   maxRetries?: number;
   initialDelay?: number;
@@ -105,6 +107,32 @@ export function createAxiosWithRetry(
 ) {
   const instance = axios.create(axiosConfig);
   const mergedRetryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+
+  // Add auth token interceptor - reads token from localStorage on each request
+  instance.interceptors.request.use(
+    (config) => {
+      const token = localStorage.getItem(AUTH_TOKEN_KEY);
+      if (token && config.headers) {
+        config.headers['X-Auth-Token'] = token;
+      }
+      return config;
+    },
+    (error) => Promise.reject(error)
+  );
+
+  // Add 401 handler interceptor
+  instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      // Handle 401 Unauthorized - clear token and trigger re-login
+      if (error.response && error.response.status === 401) {
+        localStorage.removeItem(AUTH_TOKEN_KEY);
+        // Dispatch custom event to notify AuthProvider
+        window.dispatchEvent(new CustomEvent('auth:unauthorized'));
+      }
+      return Promise.reject(error);
+    }
+  );
 
   // Add retry interceptor
   instance.interceptors.response.use(


### PR DESCRIPTION
## Summary
- Fix authentication errors and plugin marketplace access by injecting auth tokens into requests, handling 401s gracefully, and ensuring startup initializes axios defaults and error handling synchronously.

## Changes
### Core Functionality
- Add automatic X-Auth-Token header to all requests by introducing a request interceptor in retry.ts that reads the token from localStorage.
- Handle 401 Unauthorized responses by clearing the stored token and dispatching a global auth event ('auth:unauthorized') to trigger re-login flows.
- Initialize Axios defaults and global error handlers synchronously during app startup to ensure interceptors are ready before any requests (updated in main.jsx).

### Codebase Refactors
- Remove direct Axios usage in frontend/src/services/files.ts and frontend/src/services/marketplace.ts; rely on createAxiosWithRetry and centralized error handling utilities.
- Update imports accordingly (no Axios/AxiosError in marketplace.ts; use withErrorHandling, toApiError).
- Move from asynchronous dynamic imports to synchronous imports for axiosDefaults and globalErrorHandler in main.jsx for reliable interceptor setup.

## Why
- Ensures authenticated requests consistently include the auth token.
- Improves resilience to expired tokens by triggering re-login flow on 401s.
- Eliminates race conditions during startup by configuring axios defaults and error handling upfront.

## Testing plan
- [x] Start the app with a token stored in localStorage and verify API requests include the X-Auth-Token header.
- [x] Simulate 401 responses from protected endpoints and verify:
  - The token is removed from localStorage.
  - A global 'auth:unauthorized' event is dispatched to trigger login flow.
- [x] Ensure marketplace-related API calls continue to work with the token and benefit from retry logic.
- [x] Confirm startup initializes axios defaults and global error handlers before making requests.

## Files touched
- frontend/src/main.jsx: initialize axios defaults and global error handlers synchronously.
- frontend/src/services/utils/retry.ts: implement auth header interceptor and 401 handling; trigger re-login flow.
- frontend/src/services/files.ts: remove direct axios import and align with new error handling approach.
- frontend/src/services/marketplace.ts: remove Axios import; use createAxiosWithRetry and centralized error handling.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8f0c410d-5528-41a5-91be-787626f28909