### PR TITLE
Add terragon-setup.sh to orchestrate Terragon setup

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# =============================================================================
+# Terragon Setup Script
+# Master script that runs all Terragon setup components:
+# - Chrome Headless Shell (for MCP Chrome DevTools)
+# - Claude Code Superpowers and Anthropic Skills
+# Run this after each clean workspace initialization
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "======================================"
+echo "  Terragon Full Setup"
+echo "======================================"
+echo ""
+
+# =============================================================================
+# Chrome Headless Shell Setup
+# =============================================================================
+
+echo ">>> Running Chrome Headless Shell setup..."
+echo ""
+"$SCRIPT_DIR/terragon-scripts/terragon-chrome-setup.sh"
+echo ""
+
+# =============================================================================
+# Skills & Superpowers Setup
+# =============================================================================
+
+echo ">>> Running Skills & Superpowers setup..."
+echo ""
+"$SCRIPT_DIR/terragon-scripts/terragon-skills-setup.sh"
+echo ""
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo "======================================"
+echo "  Terragon Setup Complete!"
+echo "======================================"
+echo ""
+echo "Components installed:"
+echo "  ✓ Chrome Headless Shell (port 9222)"
+echo "  ✓ Claude Code Superpowers"
+echo "  ✓ Anthropic Skills"
+echo ""
+echo "You can now use MCP Chrome DevTools and enhanced Claude capabilities."


### PR DESCRIPTION
## Summary
- Introduces terragon-setup.sh, a master Terragon setup script that orchestrates multiple setup components
- Automatically runs Chrome Headless Shell setup and Skills & Superpowers setup in sequence
- Intended to run after a clean workspace initialization to streamline environment setup

## Changes
### Core Functionality
- New executable script: terragon-setup.sh
- Behavior:
  - Determines script directory for reliable path resolution
  - Echoes progress messages for visibility
  - Executes:
    - terragon-scripts/terragon-chrome-setup.sh
    - terragon-scripts/terragon-skills-setup.sh
  - Outputs a final summary listing installed components:
    - Chrome Headless Shell (port 9222)
    - Claude Code Superpowers
    - Anthropic Skills
- Ensures the script exits on any error to avoid partial setups

### Dependencies
- Relies on the terragon-scripts directory containing:
  - terragon-chrome-setup.sh
  - terragon-skills-setup.sh

## Test plan
- [x] Ensure terragon-setup.sh is executable and committed
- [x] Run the script from the repository root: ./terragon-setup.sh
- [x] Verify console output includes:
  - "Running Chrome Headless Shell setup..."
  - "Running Skills & Superpowers setup..."
  - "Terragon Setup Complete!"
- [x] Confirm Chrome Headless Shell is available on port 9222 after run
- [x] Confirm Claude Code Superpowers and Anthropic Skills components are installed (as per the underlying setup scripts)
- [ ] If any of the underlying setup scripts fail, review terragon-scripts/*.sh for prerequisites and permissions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1ed5207f-6ce5-4c2c-a0f5-c5231f66024b